### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to npm
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/Gamemodstudios/gm-webkit/security/code-scanning/1](https://github.com/Gamemodstudios/gm-webkit/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves publishing a package to npm, it likely only needs read access to the repository contents. Write permissions are not required for the `GITHUB_TOKEN` in this case.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `publish` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
